### PR TITLE
Use igniteui-cli to upgrage licensed packages 

### DIFF
--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -168,13 +168,21 @@ stages:
             echo "Checking for ignite-ui-cli.json"
             ls -alh $(Build.SourcesDirectory) | grep ignite-ui-cli.json || echo "File not found!"
 
-      - task: Npm@1
-        displayName: 'Upgrade Ignite UI Packages'
+      # - task: Npm@1
+      #   displayName: 'Upgrade Ignite UI Packages'
+      #   inputs:
+      #     verbose: ${{ parameters.isVerbose }}
+      #     command: custom
+      #     workingDir: '$(Build.SourcesDirectory)'
+      #     customCommand: 'npx ig upgrade-packages'
+
+      - task: Bash@3
+        displayName: 'Run Ignite UI Upgrade with Explicit Path'
         inputs:
-          verbose: ${{ parameters.isVerbose }}
-          command: custom
-          workingDir: '$(Build.SourcesDirectory)'
-          customCommand: 'npx ig upgrade-packages'
+          targetType: 'inline'
+          script: |
+            echo "Running Ignite UI package upgrade..."
+            $(Build.SourcesDirectory)/node_modules/.bin/npx ig upgrade-packages
 
       - task: Bash@3
         displayName: 'Output package.json after upgrade'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -125,13 +125,13 @@ stages:
           targetType: 'inline'
           script: |
             echo "Running Ignite UI package upgrade at root level..."
-            npx ig upgrade-packages
+            npx ig upgrade-packages --skip-install
 
             echo "Running Ignite UI package upgrade in all project subdirectories..."
             for dir in $(Build.SourcesDirectory)/projects/*/; do
               if [ -d "$dir" ]; then
                 echo "Processing: $dir"
-                (cd "$dir" && npx ig upgrade-packages)
+                (cd "$dir" && npx ig upgrade-packages --skip-install)
               fi
             done
 

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -166,7 +166,7 @@ stages:
           verbose: ${{ parameters.isVerbose }}
           command: custom
           workingDir: '$(Build.SourcesDirectory)'
-          customCommand: 'npx ig upgrade-packages'
+          customCommand: 'npx --version'
 
       - task: Bash@3
         displayName: 'Output package.json after upgrade'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -176,7 +176,7 @@ stages:
       #     workingDir: '$(Build.SourcesDirectory)'
       #     customCommand: 'npx ig upgrade-packages'
 
-      - task: Bash@3
+      - task: PowerShell@2
         displayName: 'Run Ignite UI Upgrade with Explicit Path'
         inputs:
           targetType: 'inline'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -160,14 +160,6 @@ stages:
           workingDir: '$(Build.SourcesDirectory)'
           customCommand: 'install -g igniteui-cli'
 
-      - task: Bash@3
-        displayName: 'Check ignite-ui-cli.json'
-        inputs:
-          targetType: 'inline'
-          script: |
-            echo "Checking for ignite-ui-cli.json"
-            cat $(Build.SourcesDirectory)/ignite-ui-cli.json
-
       # - task: Npm@1
       #   displayName: 'Upgrade Ignite UI Packages'
       #   inputs:
@@ -176,7 +168,7 @@ stages:
       #     workingDir: '$(Build.SourcesDirectory)'
       #     customCommand: 'npx ig upgrade-packages'
 
-      - task: PowerShell@2
+      - task: Bash@3
         displayName: 'Run Ignite UI Upgrade with Explicit Path'
         inputs:
           targetType: 'inline'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -160,13 +160,21 @@ stages:
           workingDir: '$(Build.SourcesDirectory)'
           customCommand: 'install -g igniteui-cli'
 
+      - task: Bash@3
+        displayName: 'Check ignite-ui-cli.json'
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "Checking for ignite-ui-cli.json"
+            ls -alh $(Build.SourcesDirectory) | grep ignite-ui-cli.json || echo "File not found!"
+
       - task: Npm@1
         displayName: 'Upgrade Ignite UI Packages'
         inputs:
           verbose: ${{ parameters.isVerbose }}
           command: custom
           workingDir: '$(Build.SourcesDirectory)'
-          customCommand: 'npx --version'
+          customCommand: 'npx ig upgrade-packages'
 
       - task: Bash@3
         displayName: 'Output package.json after upgrade'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -136,6 +136,14 @@ stages:
             done
 
       - task: Npm@1
+        displayName: 'npm install --legacy-peer-deps'
+        inputs:
+          verbose: ${{ parameters.isVerbose }}
+          command: custom
+          workingDir: '$(Build.SourcesDirectory)'
+          customCommand: 'install --legacy-peer-deps'
+
+      - task: Npm@1
         displayName: 'npm run build:ci'
         inputs:
           verbose: ${{ parameters.isVerbose }}

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -166,7 +166,7 @@ stages:
           targetType: 'inline'
           script: |
             echo "Checking for ignite-ui-cli.json"
-            ls -alh $(Build.SourcesDirectory) | grep ignite-ui-cli.json || echo "File not found!"
+            cat $(Build.SourcesDirectory)/ignite-ui-cli.json
 
       # - task: Npm@1
       #   displayName: 'Upgrade Ignite UI Packages'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -168,13 +168,29 @@ stages:
       #     workingDir: '$(Build.SourcesDirectory)'
       #     customCommand: 'npx ig upgrade-packages'
 
+      # - task: Bash@3
+      #   displayName: 'Run Ignite UI Upgrade with Explicit Path'
+      #   inputs:
+      #     targetType: 'inline'
+      #     script: |
+      #       echo "Running Ignite UI package upgrade..."
+      #       npx ig upgrade-packages
+
       - task: Bash@3
-        displayName: 'Run Ignite UI Upgrade with Explicit Path'
+        displayName: 'Run Ignite UI Upgrade in Root and All Project Subdirectories'
         inputs:
           targetType: 'inline'
           script: |
-            echo "Running Ignite UI package upgrade..."
+            echo "Running Ignite UI package upgrade at root level..."
             npx ig upgrade-packages
+
+            echo "Running Ignite UI package upgrade in all project subdirectories..."
+            for dir in $(Build.SourcesDirectory)/projects/*/; do
+              if [ -d "$dir" ]; then
+                echo "Processing: $dir"
+                (cd "$dir" && npx ig upgrade-packages)
+              fi
+            done
 
       - task: Bash@3
         displayName: 'Output package.json after upgrade'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -111,47 +111,6 @@ stages:
           customCommand: 'install --legacy-peer-deps'
           customEndpoint: 'public proget'
 
-      # - task: PowerShell@2
-      #   displayName: 'Uninstall all IG trial packages & re-install their licensed variations'
-      #   inputs:
-      #     failOnStderr: true
-      #     showWarnings: true
-      #     workingDirectory: '$(Build.SourcesDirectory)'
-      #     targetType: 'inline'
-      #     script: |
-      #       $packageJson = Get-Content -Raw .\package.json | ConvertFrom-Json
-      #       $npmUninstallPackages = "npm uninstall --save "
-      #       $npmInstallPackages = "npm install --legacy-peer-deps "
-      #       $packageJson.dependencies.PSObject.Properties | `
-      #           Where-Object {
-      #               $_.Name.StartsWith("igniteui-webcomponents-") `
-      #           } | `
-      #           ForEach-Object { `
-      #               $npmUninstallPackages += $_.Name + " "
-      #               $npmInstallPackages += "@infragistics/" + $_.Name + "@" + $_.Value + " "
-      #           }
-      #       #Cycle through .html files to do string find a replace
-      #       Get-ChildItem -Path .\projects -Recurse -Filter *.html| ForEach-Object {
-      #           $filePath = $_.FullName
-      #           $fileContent = Get-Content -Raw -Path $filePath
-      #           $updatedContent = $fileContent -replace 'igniteui-webcomponents-', '@infragistics/igniteui-webcomponents-'
-      #           $updatedContent | Set-Content -Path $filePath
-      #           Write-Host "Updated: $filePath"
-      #       }
-      #       #Cycle through .ts files to do string find a replace
-      #       Get-ChildItem -Path .\projects -Recurse -Filter *.ts | ForEach-Object {
-      #           $filePath = $_.FullName
-      #           $fileContent = Get-Content -Raw -Path $filePath
-      #           $updatedContent = $fileContent -replace '(?<!@infragistics/)igniteui-webcomponents-', '@infragistics/igniteui-webcomponents-'
-      #           $updatedContent | Set-Content -Path $filePath
-      #           Write-Host "Updated: $filePath"
-      #       }
-
-      #       Write-Host $npmUninstallPackages
-      #       Write-Host $npmInstallPackages
-      #       Invoke-Expression -Command "$npmUninstallPackages"
-      #       Invoke-Expression -Command "$npmInstallPackages"
-
       - task: Npm@1
         displayName: 'Install Ignite UI CLI globally'
         inputs:
@@ -159,22 +118,6 @@ stages:
           command: custom
           workingDir: '$(Build.SourcesDirectory)'
           customCommand: 'install -g igniteui-cli'
-
-      # - task: Npm@1
-      #   displayName: 'Upgrade Ignite UI Packages'
-      #   inputs:
-      #     verbose: ${{ parameters.isVerbose }}
-      #     command: custom
-      #     workingDir: '$(Build.SourcesDirectory)'
-      #     customCommand: 'npx ig upgrade-packages'
-
-      # - task: Bash@3
-      #   displayName: 'Run Ignite UI Upgrade with Explicit Path'
-      #   inputs:
-      #     targetType: 'inline'
-      #     script: |
-      #       echo "Running Ignite UI package upgrade..."
-      #       npx ig upgrade-packages
 
       - task: Bash@3
         displayName: 'Run Ignite UI Upgrade in Root and All Project Subdirectories'
@@ -191,14 +134,6 @@ stages:
                 (cd "$dir" && npx ig upgrade-packages)
               fi
             done
-
-      - task: Bash@3
-        displayName: 'Output package.json after upgrade'
-        inputs:
-          targetType: 'inline'
-          script: |
-            echo "Contents of package.json after upgrade:"
-            cat "$(Build.SourcesDirectory)/package.json"
 
       - task: Npm@1
         displayName: 'npm run build:ci'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -182,7 +182,7 @@ stages:
           targetType: 'inline'
           script: |
             echo "Running Ignite UI package upgrade..."
-            $(Build.SourcesDirectory)/node_modules/.bin/npx ig upgrade-packages
+            npx ig upgrade-packages
 
       - task: Bash@3
         displayName: 'Output package.json after upgrade'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -111,46 +111,64 @@ stages:
           customCommand: 'install --legacy-peer-deps'
           customEndpoint: 'public proget'
 
-      - task: PowerShell@2
-        displayName: 'Uninstall all IG trial packages & re-install their licensed variations'
+      # - task: PowerShell@2
+      #   displayName: 'Uninstall all IG trial packages & re-install their licensed variations'
+      #   inputs:
+      #     failOnStderr: true
+      #     showWarnings: true
+      #     workingDirectory: '$(Build.SourcesDirectory)'
+      #     targetType: 'inline'
+      #     script: |
+      #       $packageJson = Get-Content -Raw .\package.json | ConvertFrom-Json
+      #       $npmUninstallPackages = "npm uninstall --save "
+      #       $npmInstallPackages = "npm install --legacy-peer-deps "
+      #       $packageJson.dependencies.PSObject.Properties | `
+      #           Where-Object {
+      #               $_.Name.StartsWith("igniteui-webcomponents-") `
+      #           } | `
+      #           ForEach-Object { `
+      #               $npmUninstallPackages += $_.Name + " "
+      #               $npmInstallPackages += "@infragistics/" + $_.Name + "@" + $_.Value + " "
+      #           }
+      #       #Cycle through .html files to do string find a replace
+      #       Get-ChildItem -Path .\projects -Recurse -Filter *.html| ForEach-Object {
+      #           $filePath = $_.FullName
+      #           $fileContent = Get-Content -Raw -Path $filePath
+      #           $updatedContent = $fileContent -replace 'igniteui-webcomponents-', '@infragistics/igniteui-webcomponents-'
+      #           $updatedContent | Set-Content -Path $filePath
+      #           Write-Host "Updated: $filePath"
+      #       }
+      #       #Cycle through .ts files to do string find a replace
+      #       Get-ChildItem -Path .\projects -Recurse -Filter *.ts | ForEach-Object {
+      #           $filePath = $_.FullName
+      #           $fileContent = Get-Content -Raw -Path $filePath
+      #           $updatedContent = $fileContent -replace '(?<!@infragistics/)igniteui-webcomponents-', '@infragistics/igniteui-webcomponents-'
+      #           $updatedContent | Set-Content -Path $filePath
+      #           Write-Host "Updated: $filePath"
+      #       }
+
+      #       Write-Host $npmUninstallPackages
+      #       Write-Host $npmInstallPackages
+      #       Invoke-Expression -Command "$npmUninstallPackages"
+      #       Invoke-Expression -Command "$npmInstallPackages"
+
+      - task: Npm@1
+        displayName: 'Install Ignite UI CLI globally'
         inputs:
-          failOnStderr: true
-          showWarnings: true
-          workingDirectory: '$(Build.SourcesDirectory)'
+          verbose: ${{ parameters.isVerbose }}
+          command: custom
+          workingDir: '$(Build.SourcesDirectory)'
+          customCommand: 'install -g igniteui-cli'
+
+      - task: Bash@3
+        displayName: 'Upgrade Ignite UI Packages'
+        inputs:
           targetType: 'inline'
           script: |
-            $packageJson = Get-Content -Raw .\package.json | ConvertFrom-Json
-            $npmUninstallPackages = "npm uninstall --save "
-            $npmInstallPackages = "npm install --legacy-peer-deps "
-            $packageJson.dependencies.PSObject.Properties | `
-                Where-Object {
-                    $_.Name.StartsWith("igniteui-webcomponents-") `
-                } | `
-                ForEach-Object { `
-                    $npmUninstallPackages += $_.Name + " "
-                    $npmInstallPackages += "@infragistics/" + $_.Name + "@" + $_.Value + " "
-                }
-            #Cycle through .html files to do string find a replace
-            Get-ChildItem -Path .\projects -Recurse -Filter *.html| ForEach-Object {
-                $filePath = $_.FullName
-                $fileContent = Get-Content -Raw -Path $filePath
-                $updatedContent = $fileContent -replace 'igniteui-webcomponents-', '@infragistics/igniteui-webcomponents-'
-                $updatedContent | Set-Content -Path $filePath
-                Write-Host "Updated: $filePath"
-            }
-            #Cycle through .ts files to do string find a replace
-            Get-ChildItem -Path .\projects -Recurse -Filter *.ts | ForEach-Object {
-                $filePath = $_.FullName
-                $fileContent = Get-Content -Raw -Path $filePath
-                $updatedContent = $fileContent -replace '(?<!@infragistics/)igniteui-webcomponents-', '@infragistics/igniteui-webcomponents-'
-                $updatedContent | Set-Content -Path $filePath
-                Write-Host "Updated: $filePath"
-            }
-
-            Write-Host $npmUninstallPackages
-            Write-Host $npmInstallPackages
-            Invoke-Expression -Command "$npmUninstallPackages"
-            Invoke-Expression -Command "$npmInstallPackages"
+            echo "Running Ignite UI package upgrade..."
+            ig upgrade-packages
+            echo "Contents of package.json after upgrade:"
+            cat "$(Build.SourcesDirectory)/package.json"
 
       - task: Npm@1
         displayName: 'npm run build:ci'

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -160,13 +160,19 @@ stages:
           workingDir: '$(Build.SourcesDirectory)'
           customCommand: 'install -g igniteui-cli'
 
-      - task: Bash@3
+      - task: Npm@1
         displayName: 'Upgrade Ignite UI Packages'
+        inputs:
+          verbose: ${{ parameters.isVerbose }}
+          command: custom
+          workingDir: '$(Build.SourcesDirectory)'
+          customCommand: 'npx ig upgrade-packages'
+
+      - task: Bash@3
+        displayName: 'Output package.json after upgrade'
         inputs:
           targetType: 'inline'
           script: |
-            echo "Running Ignite UI package upgrade..."
-            ig upgrade-packages
             echo "Contents of package.json after upgrade:"
             cat "$(Build.SourcesDirectory)/package.json"
 

--- a/ignite-ui-cli.json
+++ b/ignite-ui-cli.json
@@ -1,0 +1,16 @@
+{
+  "version": "$(cliVersion)",
+  "project": {
+    "defaultPort": 8000,
+    "framework": "webcomponents",
+    "projectTemplate": "$(projectTemplate)",
+    "projectType": "igc-ts",
+    "theme": "$(theme)",
+    "isBundle": false,
+    "components": [],
+    "sourceFiles": [],
+    "isShowcase": false,
+    "version": ""
+  },
+  "build": {}
+}

--- a/projects/erp-hgrid/ignite-ui-cli.json
+++ b/projects/erp-hgrid/ignite-ui-cli.json
@@ -1,0 +1,16 @@
+{
+  "version": "$(cliVersion)",
+  "project": {
+    "defaultPort": 8000,
+    "framework": "webcomponents",
+    "projectTemplate": "$(projectTemplate)",
+    "projectType": "igc-ts",
+    "theme": "$(theme)",
+    "isBundle": false,
+    "components": [],
+    "sourceFiles": [],
+    "isShowcase": false,
+    "version": ""
+  },
+  "build": {}
+}

--- a/projects/finance-grid/ignite-ui-cli.json
+++ b/projects/finance-grid/ignite-ui-cli.json
@@ -1,0 +1,16 @@
+{
+  "version": "$(cliVersion)",
+  "project": {
+    "defaultPort": 8000,
+    "framework": "webcomponents",
+    "projectTemplate": "$(projectTemplate)",
+    "projectType": "igc-ts",
+    "theme": "$(theme)",
+    "isBundle": false,
+    "components": [],
+    "sourceFiles": [],
+    "isShowcase": false,
+    "version": ""
+  },
+  "build": {}
+}

--- a/projects/fleet-management-grid/ignite-ui-cli.json
+++ b/projects/fleet-management-grid/ignite-ui-cli.json
@@ -1,0 +1,16 @@
+{
+  "version": "$(cliVersion)",
+  "project": {
+    "defaultPort": 8000,
+    "framework": "webcomponents",
+    "projectTemplate": "$(projectTemplate)",
+    "projectType": "igc-ts",
+    "theme": "$(theme)",
+    "isBundle": false,
+    "components": [],
+    "sourceFiles": [],
+    "isShowcase": false,
+    "version": ""
+  },
+  "build": {}
+}

--- a/projects/hr-portal/ignite-ui-cli.json
+++ b/projects/hr-portal/ignite-ui-cli.json
@@ -1,0 +1,16 @@
+{
+  "version": "$(cliVersion)",
+  "project": {
+    "defaultPort": 8000,
+    "framework": "webcomponents",
+    "projectTemplate": "$(projectTemplate)",
+    "projectType": "igc-ts",
+    "theme": "$(theme)",
+    "isBundle": false,
+    "components": [],
+    "sourceFiles": [],
+    "isShowcase": false,
+    "version": ""
+  },
+  "build": {}
+}

--- a/projects/sales-grid/ignite-ui-cli.json
+++ b/projects/sales-grid/ignite-ui-cli.json
@@ -1,0 +1,16 @@
+{
+  "version": "$(cliVersion)",
+  "project": {
+    "defaultPort": 8000,
+    "framework": "webcomponents",
+    "projectTemplate": "$(projectTemplate)",
+    "projectType": "igc-ts",
+    "theme": "$(theme)",
+    "isBundle": false,
+    "components": [],
+    "sourceFiles": [],
+    "isShowcase": false,
+    "version": ""
+  },
+  "build": {}
+}


### PR DESCRIPTION
This solution uses ugniteui-cli instead of a bash script to do string find and replace for igniteui-webcomponents-* packages.

The solution was tested on staging and produces the webpage:
https://staging.infragistics.com/webcomponents-grid-examples
Another example of the finance page:
https://staging.infragistics.com/webcomponents-grid-examples/home/finance