### PR TITLE
Separate grids in build pipeline

### DIFF
--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -148,8 +148,12 @@ stages:
             echo "Running Ignite UI package upgrade in all project subdirectories..."
             for dir in $(Build.SourcesDirectory)/projects/*/; do
               if [ -d "$dir" ]; then
-                echo "Processing: $dir"
-                (cd "$dir" && npx ig upgrade-packages --skip-install)
+                if [ -f "$dir/.igniteui-cli.json" ]; then
+                  echo "Processing Ignite UI project: $dir"
+                  (cd "$dir" && npx ig upgrade-packages --skip-install)
+                else
+                  echo "Skipping $dir (not an Ignite UI CLI project)"
+                fi
               fi
             done
 

--- a/azure-pipelines/igniteui-wc-grid-examples.yml
+++ b/azure-pipelines/igniteui-wc-grid-examples.yml
@@ -77,8 +77,8 @@ stages:
               fi
             }
 
-            # Pass 1: All first-level directories in projects/
-            create_zips "$(Build.SourcesDirectory)/projects"
+            # Pass 1: All first-level directories in projects/grids/
+            create_zips "$(Build.SourcesDirectory)/projects/grids"
 
             # Pass 2: All first-level directories in projects/charts/
             create_zips "$(Build.SourcesDirectory)/projects/charts"


### PR DESCRIPTION
This PR separates grids the same way like charts in a different folder in /projects